### PR TITLE
Custom Configuration Directory

### DIFF
--- a/tests/src/Kernel/InstallsExportedConfigTest.php
+++ b/tests/src/Kernel/InstallsExportedConfigTest.php
@@ -22,16 +22,13 @@ class InstallsExportedConfigTest extends KernelTestBase
         'user',
     ];
 
-    /** @var bool */
-    private $useVfsConfigDirectory = false;
-
     /** @var string */
     private $customConfigDirectory;
 
     /** @test */
     public function throws_exception_for_bad_config(): void
     {
-        $this->useVfsConfigDirectory = true;
+        $this->useVfsConfigDirectory();
 
         $this->installEntitySchema('node');
 
@@ -46,7 +43,7 @@ class InstallsExportedConfigTest extends KernelTestBase
     /** @test */
     public function installs_config(): void
     {
-        $this->setConfigDirectory('node/bundles');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/node/bundles');
 
         $nodeTypeStorage = $this->container->get('entity_type.manager')->getStorage('node_type');
 
@@ -66,7 +63,7 @@ class InstallsExportedConfigTest extends KernelTestBase
     /** @test */
     public function install_bundle(): void
     {
-        $this->setConfigDirectory('node/bundles');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/node/bundles');
 
         $nodeTypeStorage = $this->container->get('entity_type.manager')->getStorage('node_type');
 
@@ -86,7 +83,7 @@ class InstallsExportedConfigTest extends KernelTestBase
     /** @test */
     public function install_bundles(): void
     {
-        $this->setConfigDirectory('node/bundles');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/node/bundles');
 
         $nodeTypeStorage = $this->container->get('entity_type.manager')->getStorage('node_type');
 
@@ -113,7 +110,7 @@ class InstallsExportedConfigTest extends KernelTestBase
     /** @test */
     public function install_role(): void
     {
-        $this->setConfigDirectory('roles');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/roles');
 
         $userRoleStorage = $this->container->get('entity_type.manager')->getStorage('user_role');
 
@@ -133,7 +130,7 @@ class InstallsExportedConfigTest extends KernelTestBase
     /** @test */
     public function install_roles(): void
     {
-        $this->setConfigDirectory('roles');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/roles');
 
         $userRoleStorage = $this->container->get('entity_type.manager')->getStorage('user_role');
 
@@ -164,7 +161,7 @@ class InstallsExportedConfigTest extends KernelTestBase
         ]);
         $this->installEntitySchema('taxonomy_vocabulary');
 
-        $this->setConfigDirectory('taxonomy');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/taxonomy');
 
         $vocabularyStorage = $this->container->get('entity_type.manager')->getStorage('taxonomy_vocabulary');
 
@@ -189,7 +186,7 @@ class InstallsExportedConfigTest extends KernelTestBase
         ]);
         $this->installEntitySchema('taxonomy_vocabulary');
 
-        $this->setConfigDirectory('taxonomy');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/taxonomy');
 
         $vocabularyStorage = $this->container->get('entity_type.manager')->getStorage('taxonomy_vocabulary');
 
@@ -222,10 +219,10 @@ class InstallsExportedConfigTest extends KernelTestBase
             'text',
         ]);
 
-        $this->setConfigDirectory('node/bundles');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/node/bundles');
         $this->installBundle('node', 'page');
 
-        $this->setConfigDirectory('node/fields');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/node/fields');
 
         $nodeStorage = $this->container->get('entity_type.manager')->getStorage('node');
 
@@ -255,10 +252,10 @@ class InstallsExportedConfigTest extends KernelTestBase
             'text',
         ]);
 
-        $this->setConfigDirectory('node/bundles');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/node/bundles');
         $this->installBundle('node', 'page');
 
-        $this->setConfigDirectory('node/fields');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/node/fields');
 
         $nodeStorage = $this->container->get('entity_type.manager')->getStorage('node');
 
@@ -286,7 +283,7 @@ class InstallsExportedConfigTest extends KernelTestBase
     /** @test */
     public function install_entity_schema_with_bundles(): void
     {
-        $this->setConfigDirectory('node/bundles');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/node/bundles');
 
         $entityTypeManager = $this->container->get('entity_type.manager');
 
@@ -322,7 +319,7 @@ class InstallsExportedConfigTest extends KernelTestBase
         $this->enableModules([
             'image',
         ]);
-        $this->setConfigDirectory('image_styles');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/image_styles');
 
         $imageStyleStorage = $this->container->get('entity_type.manager')->getStorage('image_style');
 
@@ -345,7 +342,7 @@ class InstallsExportedConfigTest extends KernelTestBase
         $this->enableModules([
             'image',
         ]);
-        $this->setConfigDirectory('image_styles');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/image_styles');
 
         $imageStyleStorage = $this->container->get('entity_type.manager')->getStorage('image_style');
 
@@ -379,10 +376,10 @@ class InstallsExportedConfigTest extends KernelTestBase
             'text',
         ]);
 
-        $this->setConfigDirectory('node/bundles');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/node/bundles');
         $this->installBundle('node', 'page');
 
-        $this->setConfigDirectory('node/fields');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/node/fields');
 
         $nodeStorage = $this->container->get('entity_type.manager')->getStorage('node');
 
@@ -402,27 +399,5 @@ class InstallsExportedConfigTest extends KernelTestBase
 
         $this->assertTrue($node->hasField('body'));
         $this->assertTrue($node->hasField('field_boolean_field'));
-    }
-
-    protected function configDirectory(): string
-    {
-        if ($this->useVfsConfigDirectory) {
-            return $this->InstallsExportedConfigDirectory();
-        }
-
-        $baseConfigPath = __DIR__ . '/__fixtures__/config/sync';
-
-        if ($this->customConfigDirectory) {
-            return $baseConfigPath . '/' . ltrim($this->customConfigDirectory, '/');
-        }
-
-        // providing our own directory with config we can test against
-        return $baseConfigPath;
-    }
-
-    /** sets the config directory relative to the __fixtures__ directory */
-    private function setConfigDirectory(string $directory): void
-    {
-        $this->customConfigDirectory = $directory;
     }
 }

--- a/tests/src/Kernel/InteractsWithLanguagesTest.php
+++ b/tests/src/Kernel/InteractsWithLanguagesTest.php
@@ -14,14 +14,11 @@ class InteractsWithLanguagesTest extends KernelTestBase
         'system',
     ];
 
-    /** @var string */
-    private $customConfigDirectory;
-
     protected function setUp()
     {
         parent::setUp();
 
-        $this->setConfigDirectory('languages');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/languages');
     }
 
     /** @test */
@@ -56,12 +53,12 @@ class InteractsWithLanguagesTest extends KernelTestBase
             'node',
             'user',
         ]);
-        $this->setConfigDirectory('node/bundles');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/node/bundles');
 
         $this->installEntitySchemaWithBundles('node', 'page');
         $this->installEntitySchema('user');
 
-        $this->setConfigDirectory('languages');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/languages');
 
         $noPrefixEnNode = $this->nodeStorage()->create([
             'nid' => '1000',
@@ -106,12 +103,12 @@ class InteractsWithLanguagesTest extends KernelTestBase
             'node',
             'user',
         ]);
-        $this->setConfigDirectory('node/bundles');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/node/bundles');
 
         $this->installEntitySchemaWithBundles('node', 'page');
         $this->installEntitySchema('user');
 
-        $this->setConfigDirectory('languages');
+        $this->setConfigDirectory(__DIR__ . '/__fixtures__/config/sync/languages');
 
         $enNode = $this->nodeStorage()->create([
             'title' => 'EN Node',
@@ -135,24 +132,6 @@ class InteractsWithLanguagesTest extends KernelTestBase
         ]);
         $deNode->save();
         $this->assertEquals('de', $deNode->language()->getId());
-    }
-
-    protected function configDirectory(): string
-    {
-        $baseConfigPath = __DIR__ . '/__fixtures__/config/sync';
-
-        if ($this->customConfigDirectory) {
-            return $baseConfigPath . '/' . ltrim($this->customConfigDirectory, '/');
-        }
-
-        // providing our own directory with config we can test against
-        return $baseConfigPath;
-    }
-
-    /** sets the config directory relative to the __fixtures__ directory */
-    private function setConfigDirectory(string $directory): void
-    {
-        $this->customConfigDirectory = $directory;
     }
 
     private function nodeStorage(): EntityStorageInterface

--- a/tests/src/Kernel/Testing/Concerns/InstallsExportedConfig.php
+++ b/tests/src/Kernel/Testing/Concerns/InstallsExportedConfig.php
@@ -9,6 +9,12 @@ use Drupal\Tests\test_traits\Kernel\Testing\Exceptions\ConfigInstallFailed;
 /** This trait may be used to test fields stored as field configs */
 trait InstallsExportedConfig
 {
+    /** @var string */
+    private $useVfsConfigDirectory = false;
+
+    /** @var string */
+    private $customConfigDirectory;
+
     /** @var array */
     protected $installedConfig = [];
 
@@ -148,6 +154,31 @@ trait InstallsExportedConfig
 
     protected function configDirectory(): string
     {
-        return Settings::get('config_sync_directory');
+        if ($this->useVfsConfigDirectory) {
+            return Settings::get('config_sync_directory');
+        }
+
+        if ($this->customConfigDirectory) {
+            return '/' . ltrim($this->customConfigDirectory, '/');
+        }
+
+        $root = $this->container->get('app.root');
+
+        return str_replace('web/', '', $root . '/config/sync');
+    }
+
+    /** sets the config directory relative to the __fixtures__ directory */
+    protected function setConfigDirectory(string $directory): self
+    {
+        $this->customConfigDirectory = $directory;
+
+        return $this;
+    }
+
+    protected function useVfsConfigDirectory(): self
+    {
+        $this->useVfsConfigDirectory = true;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Adding some methods to the InstallsExportedConfig trait to allow developers to set their own configuration directory in the instance they may want to use configuration file fixtures, like this package does